### PR TITLE
Use hashed set instead of vector to represent node frontier.

### DIFF
--- a/src/rules/chess/interface.cpp
+++ b/src/rules/chess/interface.cpp
@@ -44,16 +44,13 @@ bool ChessCheckmateEvaluator::operator()(const ChessBoardState& b) {
         // check, i.e. if this turn was skipped then next turn the king could be captured.
         if (inCheck(b, !b.m_player)) {
             // check and mate
-            std::cout << "LOSS" << std::endl;
             return true; // TODO: should be return LOSS
         } else {
             // mate without check is stalemate in chess
-            std::cout << "DRAW" << std::endl;
             return false; // TODO: should be return DRAW
         }
     }
     // If not a mate, game is ongoing
-    std::cout << "ONGOING" << std::endl;
     return false; // TODO: should be return ONGOING
 }
 

--- a/test/retrograde_analysis/SConstruct
+++ b/test/retrograde_analysis/SConstruct
@@ -1,0 +1,79 @@
+#!python
+import os, subprocess
+
+# This folder is where final products go
+compiled_path = "./compiled/" 
+
+opts = Variables([], ARGUMENTS)
+
+# Gets the standard flags CC, CCX, etc.
+env = DefaultEnvironment()
+
+# Define our options
+opts.Add(EnumVariable('target', "Compile targets in debug or release mode", 'debug', ['debug', 'release']))
+opts.Add(EnumVariable('platform', "Compilation platform", '', ['', 'windows', 'linux', 'osx']))
+opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
+
+# Updates the environment with the option variables.
+opts.Update(env)
+
+# Generates help for the -h scons option.
+Help("\nScrappyTBGen Compiler Options:\n---------------------------")
+Help(opts.GenerateHelpText(env))
+
+# Process some arguments
+if env['use_llvm']:
+    env['CC'] = 'clang'
+    env['CXX'] = 'clang++'
+
+# Main function of this script
+def compile():
+# ------- First, do the things that are common to all compiled targets ------- #
+    print("Platform =",  env['platform'], ("(llvm)" if  env['use_llvm'] else ''))
+    # Check our platform specifics
+    if env['platform'] == "osx":
+        if env['target'] == 'debug':
+            env.Append(CCFLAGS = ['-g','-O2', '-arch', 'x86_64', '-std=c++17'])
+            env.Append(LINKFLAGS = ['-arch', 'x86_64'])
+        else:
+            env.Append(CCFLAGS = ['-g','-O3', '-arch', 'x86_64', '-std=c++17'])
+            env.Append(LINKFLAGS = ['-arch', 'x86_64'])
+
+    elif env['platform'] == "linux":
+        env['CXX'] = 'g++'
+        env.Append(CCFLAGS = ['-fopenmp', '-std=c++20', '-O3'])
+        env.Append(LINKFLAGS = ['-fopenmp', '-std=c++20', '-O3'])
+        # if env['target'] == 'debug':
+        #     env.Append(CCFLAGS = ['-fPIC', '-g3','-Og', '-std=c++17'])
+        # else:
+        #     env.Append(CCFLAGS = ['-fPIC', '-g','-O3', '-std=c++17'])
+
+    elif env['platform'] == "windows":
+        # This makes sure to keep the session environment variables on windows,
+        # that way you can run scons in a vs 2017 prompt and it will find all the required tools
+        env.Append(ENV = os.environ)
+
+        env.Append(CCFLAGS = ['-DWIN32', '-D_WIN32', '-D_WINDOWS', '-W3', '-GR', '-D_CRT_SECURE_NO_WARNINGS'])
+        if env['target'] == 'debug':
+            env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '-MDd'])
+        else:
+            env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '-MD'])
+
+    # if env['target'] == 'debug':
+    #     env.Append(CPPDEFINES=['DEBUG'])
+
+    # Change this to choose which variant
+    sources = Glob('../../src/rules/chess/*.cpp')
+    # Core source code
+    sources.extend(Glob('../../src/core/*.cpp'))
+    sources.extend(Glob('../../src/utils/*.cpp'))
+    # Main file
+    sources.extend(['retrograde_analysis_chess.test.cpp'])
+
+    env.Program(compiled_path + 'scrappytbgen', sources)
+
+
+if env['platform'] == '':
+    print("\nNo valid target platform selected. Try `scons platform=[platform]` or add a scons.config file.\nType `scons --help` for more parameters.\n")
+else:
+    compile()

--- a/test/retrograde_analysis/retrograde_analysis_chess.test.cpp
+++ b/test/retrograde_analysis/retrograde_analysis_chess.test.cpp
@@ -1,0 +1,65 @@
+#include "../../src/retrograde_analysis/state_transition.hpp"
+#include "../../src/retrograde_analysis/checkmate_generation.hpp"
+#include "../../src/retrograde_analysis/retrograde_analysis.hpp"
+
+#include "../../src/rules/chess/interface.h"
+
+#include <iostream>
+
+//void print_win(auto w, int v)
+//{
+//#pragma omp critical
+//  {
+//    std::cout << "found win at v=" << v << std::endl;
+//    std::cout << "Player: " << w.m_player << std::endl;
+//    auto b = w.m_board;
+//    
+//    int count = 0;
+//    for (auto c : b)
+//    {
+//      if (c == '\0')
+//        std::cout << "x ";
+//      else
+//        std::cout << c << " ";
+//      ++count;
+//      if (count % 8 == 0)
+//        std::cout << std::endl;
+//    }
+//  }
+//}
+
+int main()
+{
+  auto fwdMoveGenerator = ChessGenerateForwardMoves();
+  auto revMoveGenerator = ChessGenerateReverseMoves();
+  auto winCondEvaluator = ChessCheckmateEvaluator();
+  auto boardPrinter = ChessBoardPrinter();
+
+  constexpr ::std::size_t N      = 3;
+  constexpr ::std::size_t ROW_SZ = 8;
+  constexpr ::std::size_t COL_SZ = 8;
+  
+  // TODO: This is hardcoded for now. playout for correctness
+  std::vector<piece_label_t> noRoyaltyPieceset = { 'Q' };
+  std::vector<piece_label_t> royaltyPieceset = { 'k', 'K' };
+
+  std::vector<piece_label_t> fullPieceset = { 'k', 'K', 'q' };
+  
+  //auto checkmates = generateAllCheckmates<64, ChessNPD, N, ROW_SZ, COL_SZ,
+  //  decltype(winCondEvaluator)>(noRoyaltyPieceset, royaltyPieceset, evaluator);
+  
+  auto checkmates = generateConfigCheckmates<64, ChessNPD, N, ROW_SZ, COL_SZ,
+       decltype(winCondEvaluator)>(fullPieceset, winCondEvaluator);
+  
+  std::cout << "done with checkmates" << std::endl;
+
+  auto [wins, losses] = retrogradeAnalysisBaseImpl<64, ChessNPD, 3, ROW_SZ, 
+    COL_SZ, decltype(fwdMoveGenerator), decltype(revMoveGenerator)>(::std::move(checkmates),
+      fwdMoveGenerator, revMoveGenerator);
+  
+  std::cout << wins.size() << " " << losses.size() << std::endl;
+  //for (auto& l : checkmates)
+  //  print_win(l, 0);
+
+  return 0;
+}


### PR DESCRIPTION
In order to prune duplicate states from being explored (and causing an explosion in the size of the next iteration's frontier), we switch from using `std::vector` to `std::unordered_set` which uses the the `BoardState` hash function. To parallelize exploration of the frontier, we now parallelize over the buckets of the frontier set.

This PR also includes some cleanup and test code.